### PR TITLE
[RFC] Replace use of static TLS slot with pthread_[get|set]specific

### DIFF
--- a/opengl/libagl/context.h
+++ b/opengl/libagl/context.h
@@ -580,7 +580,9 @@ private:
 // state
 // ----------------------------------------------------------------------------
 
-#ifdef __ANDROID__
+// XXX - disable the use of bionic's dedicated slot and fall back to
+// pthread_setspecific.
+#ifdef __ANDROID__ && XXX_DISABLED
     // We have a dedicated TLS slot in bionic
     inline void setGlThreadSpecific(ogles_context_t *value) {
         __get_tls()[TLS_SLOT_OPENGL] = value;

--- a/opengl/libs/EGL/egl.cpp
+++ b/opengl/libs/EGL/egl.cpp
@@ -241,8 +241,10 @@ void gl_noop() {
 // ----------------------------------------------------------------------------
 
 void setGlThreadSpecific(gl_hooks_t const *value) {
-    gl_hooks_t const * volatile * tls_hooks = get_tls_hooks();
-    tls_hooks[TLS_SLOT_OPENGL_API] = value;
+    // XXX - Replace bionic's dedicated TLS slot with pthread_setspecific
+    //gl_hooks_t const * volatile * tls_hooks = get_tls_hooks();
+    //tls_hooks[TLS_SLOT_OPENGL_API] = value;
+    pthread_setspecific(TLS_SLOT_OPENGL_API, (const void *) value);
 }
 
 // ----------------------------------------------------------------------------

--- a/opengl/libs/EGL/getProcAddress.cpp
+++ b/opengl/libs/EGL/getProcAddress.cpp
@@ -34,6 +34,9 @@ namespace android {
 #undef GL_EXTENSION_LIST
 #undef GET_TLS
 
+
+// XXX - Inhibit optimized jumps through bionic's TLS slot
+#if 0
 #if defined(__arm__)
 
     #define GET_TLS(reg) "mrc p15, 0, " #reg ", c13, c0, 3 \n"
@@ -187,6 +190,7 @@ namespace android {
                 :                                                   \
             );
 
+#endif
 #endif
 
 #if defined(CALL_GL_EXTENSION_API)

--- a/opengl/libs/hooks.h
+++ b/opengl/libs/hooks.h
@@ -34,7 +34,9 @@
 #include <GLES3/gl32.h>
 
 // set to 1 for debugging
-#define USE_SLOW_BINDING    0
+// XXX - Enable USE_SLOW_BINDING to use traditional dlsym jumps instead
+// of using the path through the TLS hook.
+#define USE_SLOW_BINDING    1
 
 #undef NELEM
 #define NELEM(x)            (sizeof(x)/sizeof(*(x)))
@@ -76,6 +78,7 @@ struct gl_hooks_t {
 
 EGLAPI void setGlThreadSpecific(gl_hooks_t const *value);
 
+#if 0
 // We have a dedicated TLS slot in bionic
 inline gl_hooks_t const * volatile * get_tls_hooks() {
     volatile void *tls_base = __get_tls();
@@ -83,11 +86,14 @@ inline gl_hooks_t const * volatile * get_tls_hooks() {
             reinterpret_cast<gl_hooks_t const * volatile *>(tls_base);
     return tls_hooks;
 }
+#endif
 
 inline EGLAPI gl_hooks_t const* getGlThreadSpecific() {
-    gl_hooks_t const * volatile * tls_hooks = get_tls_hooks();
-    gl_hooks_t const* hooks = tls_hooks[TLS_SLOT_OPENGL_API];
-    return hooks;
+    // XXX - Replace bionic's dedicated TLS slot with pthread_getspecific
+    //gl_hooks_t const * volatile * tls_hooks = get_tls_hooks();
+    //gl_hooks_t const* hooks = tls_hooks[TLS_SLOT_OPENGL_API];
+    //return hooks;
+    return (gl_hooks_t const *) pthread_getspecific(TLS_SLOT_OPENGL_API);
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
This should avoid the conflict between bionic's statically
allocated TLS slots and glibc's linker TLS use.

We can't use __thread as tls_hooks is being used by three
different libraries (EGL, GLES2, GLES_CM).

I didn't have the time to do some proper testing, but
test_hwcomposer seems to run without TLS pollution.

This is intended just as a PoC, do NOT merge.