### PR TITLE
SensorService: don't contact batterystats service

### DIFF
--- a/services/sensorservice/BatteryService.cpp
+++ b/services/sensorservice/BatteryService.cpp
@@ -91,6 +91,7 @@ void BatteryService::cleanupImpl(uid_t uid) {
 }
 
 bool BatteryService::checkService() {
+#if 0
     if (mBatteryStatService == nullptr) {
         const sp<IServiceManager> sm(defaultServiceManager());
         if (sm != NULL) {
@@ -98,6 +99,7 @@ bool BatteryService::checkService() {
             mBatteryStatService = interface_cast<IBatteryStats>(sm->getService(name));
         }
     }
+#endif
     return mBatteryStatService != nullptr;
 }
 


### PR DESCRIPTION
This service is normally in Java part. minimediaservice have a stub
implementation for this service, but some port may choose not to run it.

Change-Id: I20aa2f00d6f55ac14a77ad33bde10b51e26b9967