### PR TITLE
get rid of droid-hybris

### DIFF
--- a/cmds/servicemanager/servicemanager.rc
+++ b/cmds/servicemanager/servicemanager.rc
@@ -1,5 +1,5 @@
 service servicemanager /system/bin/servicemanager
-    setenv LD_PRELOAD /usr/libexec/droid-hybris/system/lib64/libselinux_stubs.so
+    setenv LD_PRELOAD /system/lib64/libselinux_stubs.so
     class core animation
     user system
     group system readproc
@@ -18,18 +18,18 @@ service servicemanager /system/bin/servicemanager
     writepid /dev/cpuset/system-background/tasks
     shutdown critical
 
-service minimedia /usr/libexec/droid-hybris/system/bin/minimediaservice
+service minimedia /system/bin/minimediaservice
     class main
     user media
     group audio camera
     ioprio rt 4
 
-service minisf /usr/libexec/droid-hybris/system/bin/minisfservice
+service minisf /system/bin/minisfservice
     class main
     user system
     group graphics
 
-service miniaf /usr/libexec/droid-hybris/system/bin/miniafservice
+service miniaf /system/bin/miniafservice
     class main
     user system
     group audio


### PR DESCRIPTION
/usr/libexec/droid-hybris/ is only used with SailfishOS, not with Halium

Change-Id: I282f6f128bdee30f2878c89fd2e8f84a4a36d2c2